### PR TITLE
URL-escape postgres connection string

### DIFF
--- a/db/sqldb.go
+++ b/db/sqldb.go
@@ -3,6 +3,8 @@ package db
 import (
     "database/sql"
     "fmt"
+    "log"
+    "net/url"
     "time"
 
     _ "github.com/lib/pq"
@@ -16,10 +18,19 @@ type SqlDatabase struct {
     Conn *sql.DB
 }
 
-func InitSqlDatabase(cfg Config) (*SqlDatabase, error) {
+func getConnectionString(cfg Config) string {
     connectionString := fmt.Sprintf("postgres://%s:%s@%s/%s?sslmode=disable",
                                     cfg.Db_username, cfg.Db_pass, cfg.Db_host, cfg.Db_name)
-    fmt.Printf("Connecting to %s ... \n", connectionString)
+    u, err := url.Parse(connectionString)
+    if err != nil {
+        log.Fatal(err)
+    }
+    return u.EscapedPath()
+}
+
+func InitSqlDatabase(cfg Config) (*SqlDatabase, error) {
+    connectionString := getConnectionString(cfg)
+    log.Printf("Connecting to %s ... \n", connectionString)
     conn, err := sql.Open("postgres", connectionString)
     if err != nil {
         return nil, err

--- a/db/sqldb.go
+++ b/db/sqldb.go
@@ -20,17 +20,16 @@ type SqlDatabase struct {
 
 func getConnectionString(cfg Config) string {
 	connectionString := fmt.Sprintf("postgres://%s:%s@%s/%s?sslmode=disable",
-		cfg.Db_username, cfg.Db_pass, cfg.Db_host, cfg.Db_name)
-	u, err := url.Parse(connectionString)
-	if err != nil {
-		log.Fatal(err)
-	}
-	return u.EscapedPath()
+		url.PathEscape(cfg.Db_username),
+		url.PathEscape(cfg.Db_pass),
+		url.PathEscape(cfg.Db_host),
+		url.PathEscape(cfg.Db_name))
+	return connectionString
 }
 
 func InitSqlDatabase(cfg Config) (*SqlDatabase, error) {
 	connectionString := getConnectionString(cfg)
-	log.Printf("Connecting to %s ... \n", connectionString)
+	log.Printf("Connecting to Postgres DB ... \n")
 	conn, err := sql.Open("postgres", connectionString)
 	if err != nil {
 		return nil, err

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
         environment:
             POSTGRES_DB: starttls_dev
             POSTGRES_USER: postgres
-            POSTGRES_PASSWORD: postgres
+            POSTGRES_PASSWORD: "postgres password"
         ports:
           - "5432:5432"
     app:
@@ -21,5 +21,5 @@ services:
         environment:
             DB_NAME: starttls_dev
             DB_USERNAME: postgres
-            DB_PASSWORD: postgres
+            DB_PASSWORD: "postgres password"
             DB_HOST: postgres


### PR DESCRIPTION
Fixes #8.
Larger `fmt.Println => log.Println` refactor incoming to support #9