### PR TITLE
Hide e-mail from JSON object.

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -14,9 +14,9 @@ import (
 // ScanData each represent the result of a single scan, conducted using
 // starttls-checker.
 type ScanData struct {
-    Domain     string           // Input domain
-    Data       string           // JSON blob: scan results from starttls-checker
-    Timestamp  time.Time        // Time at which this scan was conducted
+    Domain     string       `json:"domain"`    // Input domain
+    Data       string       `json:"scandata"`  // JSON blob: scan results from starttls-checker
+    Timestamp  time.Time    `json:"timestamp"` // Time at which this scan was conducted
 }
 
 // DomainStatus: represents the state of a single domain.
@@ -32,18 +32,18 @@ const (
 
 // DomainData stores the preload state of a single domain.
 type DomainData struct {
-    Name       string           // Domain that is preloaded
-    Email      string           // Contact e-mail for Domain
-    MXs        []string         // MXs that are valid for this domain
-    State      DomainState
+    Name       string       `json:"domain"`    // Domain that is preloaded
+    Email      string       `json:"-"`         // Contact e-mail for Domain
+    MXs        []string     `json:"mxs"`       // MXs that are valid for this domain
+    State      DomainState  `json:"state"`
 }
 
 // TokenData stores the state of an e-mail verification token.
 type TokenData struct {
-    Domain       string         // Domain for which we're verifying the e-mail.
-    Token        string         // Token that we're expecting.
-    Expires      time.Time      // When this token expires.
-    Used         bool           // Whether this token was used.
+    Domain       string     `json:"domain"`    // Domain for which we're verifying the e-mail.
+    Token        string     `json:"token"`     // Token that we're expecting.
+    Expires      time.Time  `json:"expires"`   // When this token expires.
+    Used         bool       `json:"used"`      // Whether this token was used.
 }
 
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main_test
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -53,12 +54,7 @@ func TestGetDomainHidesEmail(t *testing.T) {
 	resp := testRequest("GET", "/api/queue?domain=eff.org", api.Queue)
 	// Check to see domain JSON hides email
 	domainBody, _ := ioutil.ReadAll(resp.Body)
-	var domainObj map[string]interface{}
-	json.Unmarshal(domainBody, &domainObj)
-	if _, ok := domainObj["email"]; ok {
-		t.Errorf("Domain object includes e-mail address!")
-	}
-	if _, ok := domainObj["Email"]; ok {
+	if bytes.Contains(domainBody, []byte("testing@fake-email.org")) {
 		t.Errorf("Domain object includes e-mail address!")
 	}
 }


### PR DESCRIPTION
Fixes #7 

Eventually, we may want to be able to retrieve these e-mails via an authenticated endpoint; I think in this case, we should create a differently-permissioned set of objects to deserialize the SQL rows into.